### PR TITLE
feat: enable using --usedefaultconfig flag to set regions and provinces settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,9 @@ Runs the `npm run generate` script with the `--inspect` flag, enabling it for de
 #### Example Usage
 `npm run generate --region="Region V"`<br>
 `npm run generate --region=Bangsamoro`<br>
-`npm run generate --region="Region V" --usedefault=true`<br>
+`npm run generate --region="Region V" --usedefaultconfig`<br>
+`npm run generate --region="Negros Island Region" --usedefaultexcel`
+`npm run generate --region="Region II" --usedefaultexcel --usedefaultconfig`
 `npm run generate --region"Region V" --seasons=2`
 
 ### Flags
@@ -77,9 +79,11 @@ Runs the `npm run generate` script with the `--inspect` flag, enabling it for de
   - Region name. Enclose region names with more than (1) one word between single quotes.
 - `--seasons`
    - (Optional) Number of cropping seasons. Defaults to `1`.
-- `--usedefault`
-  - Flag to use [ph-municipalities's](https://www.npmjs.com/package/ph-municipalities) local (old) Excel file as data source if `--usedefault=true`.
+- `--usedefaultexcel`
+  - (Optional) Flag to use [ph-municipalities'](https://www.npmjs.com/package/ph-municipalities) local (old) Excel file as data source if provided with the `--usedefaultexcel` flag. Defaults to `false`
   - Downloads the latest PAGASA 10-day weather forecast Excel file (day1.xlsx) by default if ommitted.
+- `--usedefaultconfig`
+   - (Optional) Flag to use ph-municipalities' default [`regions.json`](https://github.com/ciatph/ph-municipalities/blob/dev/app/config/regions.json) configuration file for regions-to-province grouping if provided with the `--usedefaultconfig` flag. Defaults to `false`, using the custom regions settings at `/src/lib/scripts/regions_20250724.json` file.
 
 ### `npm run lint`
 

--- a/src/lib/getargs.js
+++ b/src/lib/getargs.js
@@ -1,4 +1,17 @@
 /**
+ * Converts string "true" or "false" to boolean
+ * @param {string} inputStr - input value ("true" or "false" only)
+ * @returns {boolean} Boolean conversion of `inputStr`
+ * @throws {Error} Throws an error if `inputStr` contains unexpected values
+ */
+const stringToBool = (inputStr) => {
+  if (inputStr === 'true') return true
+  if (['false', ''].includes(inputStr)) return false
+
+  throw new Error('Cannot convert string to boolean')
+}
+
+/**
  * Get the nodejs cli input parameter values
  * @param {String[]} params - Array of cli input params
  * @returns {Object} Input params with user-input values
@@ -8,8 +21,12 @@ const getargs = ({
   optional = []
 }) => {
   const args = params.reduce((collection, param) => {
-    if (process.env[`npm_config_${param}`] !== undefined) {
-      collection[param] = process.env[`npm_config_${param}`]
+    const input = process.env[`npm_config_${param}`]
+
+    if (input !== undefined) {
+      collection[param] = ['true', 'false', ''].includes(input)
+        ? stringToBool(input)
+        : input
     }
 
     return { ...collection }

--- a/src/scripts/main.js
+++ b/src/scripts/main.js
@@ -1,42 +1,91 @@
 require('dotenv').config()
+const path = require('path')
 const CroppingCalendarGenerator = require('../classes/generator')
+
 const getargs = require('../lib/getargs')
+const { readJSON } = require('../lib/file')
 
 const newRegionsConfig = require('./regions_20250724.json')
 
+/**
+ * Returns configuration settings from user CLI input
+ * @param {object} cliInput - User input from CLI command
+ * @returns {object} settings - Settings object from CLI input
+ * - `settings.useLocal` - Flag to use ph-municipalities's local (old) Excel file as data source.
+ *    If `true`, will download the remote Exel file from EXCEL_FILE_URL after calling `this.init()`
+ * - `settings.useDefaultConfig` - Flag to use the new regions.json config file (loaded from require())
+ * - `settings.filePath` if `useLocal=true`, returns the path to the default local Excel file for input.
+ *  If `useLocal=false` returns a file path to contain the remote Excel file download
+ * - `settings.regionsConfig` - default or custom regions and provinces config settings
+ */
+const processInput = (cliInput) => {
+  const useLocal = cliInput?.usedefaultexcel ?? false
+  const useDefaultConfig = cliInput?.usedefaultconfig ?? false
+
+  const dataSource = useLocal ? 'LOCAL' : 'REMOTE'
+  const customRegions = useDefaultConfig ? 'DEFAULT' : 'CUSTOM'
+
+  console.log(`[LOG]: Loading Excel file from ${dataSource} source`)
+  console.log(`[LOG]: Using ${customRegions} regions/provinces settings`)
+
+  // Load the municipalities list from local or download from remote Excel source
+  const filePath = useLocal
+    ? path.join(__dirname, '..', '..', 'node_modules', 'ph-municipalities', 'data', 'day1.xlsx')
+    : path.join(__dirname, '..', '..', 'tempDowloadExcel.xlsx')
+
+  // Use the default or new regions config file
+  const regionsConfig = useDefaultConfig
+    ? readJSON(path.join(__dirname, '..', '..', 'node_modules', 'ph-municipalities', 'config', 'regions.json'))
+    : newRegionsConfig
+
+  return {
+    useLocal,
+    useDefaultConfig,
+    filePath,
+    regionsConfig
+  }
+}
+
+/** Main program start */
 const main = async () => {
   try {
     // CLI args input
     const input = getargs({
-      params: ['region', 'usedefault', 'seasons'],
-      optional: ['region', 'usedefault', 'seasons']
+      params: ['region', 'seasons', 'usedefaultexcel', 'usedefaultconfig'],
+      optional: ['region', 'seasons', 'usedefaultexcel', 'usedefaultconfig']
     })
 
-    // Initialize class
-    const useDefaultExcel = input?.usedefault ?? false
-    const generator = new CroppingCalendarGenerator(
-      { useLocal: useDefaultExcel },
-      newRegionsConfig
-    )
+    const { useLocal, filePath, regionsConfig } = processInput(input)
+
+    // Initialize class (extending the `Excelfile` class)
+    const generator = new CroppingCalendarGenerator({
+      pathToFile: filePath,
+      settings: regionsConfig,
+      ...(!useLocal && ({ url: process.env.EXCEL_FILE_URL })),
+      ...(useLocal && ({ fastload: true }))  // Load the contents of the default local Excel file
+    })
+
+    if (!useLocal) {
+      // Download the latest remote Excel file from EXCEL_FILE_URL.
+      // Stores data in generator.file after download.
+      await generator.init()
+    }
 
     // Region name from input or .env file
     const regionName = input?.region ?? process.env.REGION_NAME
     const numSeasons = input?.seasons ? +input.seasons : 1
 
-    // Download the latest remote Excel file from EXCEL_FILE_URL
-    await generator.initRemote()
-
     // Log the region names
-    const regionList = generator.regions.data.map(region => region.name)
+    const regionList = generator.listRegions()
     console.log('\nREGION NAMES')
     console.log(regionList)
     console.log('\nLooking for region: ', regionName)
 
     // List the municipalities grouped into provinces
-    const provinces = generator.regions.data.find(province => province.name === regionName)?.provinces ?? []
+    const provinces = generator.listProvinces(regionName) ?? []
 
     console.log('\nMUNICIPALITIES')
-    const municipalities = generator.file.listMunicipalities({ provinces })
+    const municipalities = generator.listMunicipalities({ provinces })
     console.log(municipalities)
 
     console.log('\nPROVINCES')


### PR DESCRIPTION
- Feat: use --usedefaultconfig flag to set the regions and provinces settings, [#23](https://github.com/ciatph/crop-calendar-generator/issues/23)
- Perf: extends the Excelfile class in CroppingCalendarGenerator class