### PR TITLE
v1.2.0

### DIFF
--- a/src/classes/generator.js
+++ b/src/classes/generator.js
@@ -72,7 +72,7 @@ class CroppingCalendarGenerator extends ExcelFile {
    * @param {number} [numCropSeasons] - (Optional) Number of cropping seasons. Defaults to `1`.
    */
   generateRandomCalendar (regionName, numCropSeasons = 1) {
-    const provinces = this.listRegions()
+    const provinces = this.listProvinces(regionName)
     const municipalities = this.listMunicipalities({ provinces })
     let objects = []
 


### PR DESCRIPTION
- Fix: use correct function listing the province names, follow-up for [PR #25](https://github.com/ciatph/crop-calendar-generator/pull/25) 